### PR TITLE
u-boot-variscite: Apply NAND patches only for var-som-mx6 machine

### DIFF
--- a/layers/meta-resin-imx6ul-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
@@ -15,9 +15,13 @@ SRC_URI_append = " \
     file://0001-Fix-SPL-compile-error-with-gcc-7.3.0.patch \
     file://mx6-var-som-integrate-with-resin-configuration.patch \
     file://mx7-var-som-integrate-with-balena-configuration.patch \
+"
+
+SRC_URI_append_var-som-mx6 = " \
     file://0001-Load-kernel-and-rootfs-from-MMC-when-booting-from-NA.patch \
     file://0001-load-splash-emmc.patch \
 "
+
 SRC_URI_append_imx7-var-som = " \
     file://0001-Revert-imx-mx7-spl-Support-mask-3N09P-of-i.MX7-revis.patch \
 "


### PR DESCRIPTION
This change applies the NAND u-boot patches only for the var-som-mx6
machine to avoid patching failure for var-som-mx8 machine, that
uses a different revision of the sources

Changelog-entry: u-boot-variscite: Apply NAND patches only for var-som-mx6 machine
Signed-off-by: Sebastian Panceac <sebastian@balena.io>