### PR TITLE
pm-utils: Add pm-utils for imx8m-var-dart

### DIFF
--- a/layers/meta-resin-imx6ul-var-dart/recipes-bsp/pm-utils-mx8/pm-utils-mx8.bb
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-bsp/pm-utils-mx8/pm-utils-mx8.bb
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+SRC_URI_append_imx8m-var-dart = " \
+        file://imx8m-wifi.sh \
+"
+
+FILES_${PN} += "/etc/pm/sleep.d/*"
+
+do_install_append_imx8m-var-dart() {
+	install -d ${D}/${sysconfdir}/pm/sleep.d
+	install -m 0755 ${WORKDIR}/imx8m-wifi.sh ${D}/${sysconfdir}/pm/sleep.d
+}

--- a/layers/meta-resin-imx6ul-var-dart/recipes-bsp/pm-utils-mx8/pm-utils-mx8/imx8m-wifi.sh
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-bsp/pm-utils-mx8/pm-utils-mx8/imx8m-wifi.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. /etc/wifi/variscite-wifi.conf
+. /etc/wifi/variscite-wifi-common.sh
+
+# Exit if WIFI is not available
+if grep -q MX8M /sys/devices/soc0/soc_id && \
+   ! grep -q WIFI /sys/devices/soc0/machine ; then
+        exit 0
+fi
+
+case $1 in
+
+"suspend")
+        wifi_down
+        ;;
+"resume")
+        wifi_up
+        ;;
+esac
+

--- a/layers/meta-resin-imx6ul-var-dart/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-core/images/resin-image.inc
@@ -95,6 +95,8 @@ IMAGE_INSTALL_append_imx8m-var-dart = " \
                                         bcm43xx-utils-mx8 \
                                         brcm-patchram-plus \
                                         kernel-modules \
+                                        pm-utils \
+                                        pm-utils-mx8 \
                                         bluez5 \
 "
 


### PR DESCRIPTION
Added pm-utils to image as well as pm-utils
scripts to reload wifi modules, as provided
by Variscite bsp layer

Changelog-entry: pm-utils: Add pm-utils for imx8m-var-dart
Signed-off-by: Alexandru Costache <alexandru@balena.io>