### PR TITLE
linux-variscite: Build net/dummy as module

### DIFF
--- a/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -16,3 +16,9 @@ SRC_URI_append_imx7-var-som = " \
 	file://0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
 	file://0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
 "
+
+# This adds support for creating dummy net devices
+RESIN_CONFIGS_append = " dummy"
+RESIN_CONFIGS[dummy] = " \
+	CONFIG_DUMMY=m \
+"


### PR DESCRIPTION
Add dummy net driver support, which is used to
check if a container is privileged during
udev initialization.

Building it as module ensures that dummy
devices are not needlessly created during boot.

This commit is taken from Alex's PR
https://github.com/balena-os/meta-balena/pull/1703/commits
so we can drop these changes here when a meta-balena with
that PR is released and we will use it.

Changelog-entry: Build net/dummy as module
Signed-off-by: Florin Sarbu <florin@balena.io>