### PR TITLE
u-boot: Switch imx6ul-var-dart environment to built-in

### DIFF
--- a/layers/meta-balena-imx6ul-var-dart/recipes-bsp/u-boot/patches/0001-fat-Fix-file-write-failure-when-saving-bootcount.patch
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-bsp/u-boot/patches/0001-fat-Fix-file-write-failure-when-saving-bootcount.patch
@@ -1,0 +1,29 @@
+From d760eae787a14c5d2938d623570402d0d2bc0a9c Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Wed, 6 Nov 2019 16:31:54 +0100
+Subject: [PATCH] fat: Fix file write failure when saving bootcount
+
+Backported from https://patchwork.ozlabs.org/patch/924967/
+
+Upstream-status: Inappropriate [backport]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ include/fat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/fat.h b/include/fat.h
+index fa95644..6a25fac 100644
+--- a/include/fat.h
++++ b/include/fat.h
+@@ -181,7 +181,7 @@ static inline u32 clust_to_sect(fsdata *fsdata, u32 clust)
+ 	return fsdata->data_begin + clust * fsdata->clust_size;
+ }
+ 
+-static inline u32 sect_to_clust(fsdata *fsdata, u32 sect)
++static inline u32 sect_to_clust(fsdata *fsdata, int sect)
+ {
+ 	return (sect - fsdata->data_begin) / fsdata->clust_size;
+ }
+-- 
+2.7.4
+

--- a/layers/meta-balena-imx6ul-var-dart/recipes-bsp/u-boot/patches/imx6ul-var-dart-integrate-with-resin-configuration.patch
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-bsp/u-boot/patches/imx6ul-var-dart-integrate-with-resin-configuration.patch
@@ -1,32 +1,41 @@
-From 26ed5d41908568b60b1d122eb72b684c2a058746 Mon Sep 17 00:00:00 2001
+From 212a6fe1ef3a4b97820d52ab36ce684bccb871e8 Mon Sep 17 00:00:00 2001
 From: Florin Sarbu <florin@resin.io>
-Date: Thu, 4 Oct 2018 07:42:45 +0200
+Date: Wed, 6 Nov 2019 15:27:21 +0100
 Subject: [PATCH] imx6ul-var-dart machine specific integration of resin
  environment configuration.
 
 Upstream-Status: Inappropriate [configuration]
-
 Signed-off-by: Florin Sarbu <florin@resin.io>
 ---
- configs/mx6ul_var_dart_mmc_defconfig | 2 ++
- include/configs/mx6ul_var_dart.h     | 9 +++++++--
- 2 files changed, 9 insertions(+), 2 deletions(-)
+ configs/mx6ul_var_dart_mmc_defconfig |  5 ++++-
+ include/configs/mx6ul_var_dart.h     | 11 ++++++++---
+ 2 files changed, 12 insertions(+), 4 deletions(-)
 
 diff --git a/configs/mx6ul_var_dart_mmc_defconfig b/configs/mx6ul_var_dart_mmc_defconfig
-index 8324fe8..b27d41d 100644
+index e034a65..091640a 100644
 --- a/configs/mx6ul_var_dart_mmc_defconfig
 +++ b/configs/mx6ul_var_dart_mmc_defconfig
-@@ -47,3 +47,5 @@ CONFIG_G_DNL_VENDOR_NUM=0x0525
- CONFIG_G_DNL_PRODUCT_NUM=0xa4a5
+@@ -35,7 +35,7 @@ CONFIG_CMD_EXT4=y
+ CONFIG_CMD_EXT4_WRITE=y
+ CONFIG_CMD_FAT=y
+ CONFIG_CMD_FS_GENERIC=y
+-CONFIG_ENV_IS_IN_MMC=y
++#CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_GADGET=y
+@@ -47,3 +47,6 @@ CONFIG_USB_GADGET_DOWNLOAD=y
+ CONFIG_VIDEO=y
  # CONFIG_VIDEO_SW_CURSOR is not set
  CONFIG_OF_LIBFDT=y
 +CONFIG_PARTITION_UUIDS=y
 +CONFIG_CMD_PART=y
++CONFIG_ENV_IS_NOWHERE=y
 diff --git a/include/configs/mx6ul_var_dart.h b/include/configs/mx6ul_var_dart.h
-index 0839185..6349db3 100644
+index f0d2838..21a79df 100644
 --- a/include/configs/mx6ul_var_dart.h
 +++ b/include/configs/mx6ul_var_dart.h
-@@ -78,7 +78,7 @@
+@@ -79,7 +79,7 @@
  	"mmcbootpart=1\0" \
  	"mmcrootpart=2\0" \
  	"mmcargs=setenv bootargs console=${console},${baudrate} " \
@@ -35,7 +44,7 @@ index 0839185..6349db3 100644
  		"${cma_size}\0" \
  	"loadbootenv=" \
  		"load mmc ${mmcdev}:${mmcbootpart} ${loadaddr} ${bootdir}/${bootenv}\0" \
-@@ -120,6 +120,11 @@
+@@ -121,6 +121,11 @@
  #else
  #define BOOT_ENV_SETTINGS	MMC_BOOT_ENV_SETTINGS
  #define CONFIG_BOOTCOMMAND \
@@ -47,15 +56,21 @@ index 0839185..6349db3 100644
  	"run ramsize_check; " \
  	"mmc dev ${mmcdev};" \
  	"mmc dev ${mmcdev}; if mmc rescan; then " \
-@@ -310,7 +315,7 @@
+@@ -273,12 +278,12 @@
  
  #if defined(CONFIG_ENV_IS_IN_MMC)
  #define CONFIG_ENV_OFFSET		(14 * SZ_64K)
 -#define CONFIG_ENV_SIZE			SZ_8K
-+#define CONFIG_ENV_SIZE			0x3000
  #elif defined(CONFIG_ENV_IS_IN_NAND)
  #define CONFIG_ENV_OFFSET		0x400000
- #define CONFIG_ENV_SIZE			SZ_128K
+-#define CONFIG_ENV_SIZE			SZ_128K
+ #endif
+ 
++#define CONFIG_ENV_SIZE                 0x3000
++
+ #define CONFIG_FAT_WRITE
+ 
+ #ifdef CONFIG_CMD_NAND
 -- 
 2.7.4
 

--- a/layers/meta-balena-imx6ul-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-bsp/u-boot/u-boot-variscite.bbappend
@@ -10,6 +10,7 @@ SRC_URI_append = " \
     file://0001-Fix-SPL-compile-error-with-gcc-7.3.0.patch \
     file://mx6-var-som-integrate-with-resin-configuration.patch \
     file://mx7-var-som-integrate-with-balena-configuration.patch \
+    file://0001-fat-Fix-file-write-failure-when-saving-bootcount.patch \
 "
 
 SRC_URI_append_var-som-mx6 = " \


### PR DESCRIPTION
ENV_SIZE was defined only for eMMC.
If there was a failure in loading env, default
would be loaded but it's size wasn't large enough
to fit it.

Switch to default env, keep 12K size regardless
of location.

```
*** Error - default environment is too large
...
Error (-1): cannot determine file size
...
Normal Boot
env_buf [32 bytes] too small for value of "bootcmd"
```

Another issue was failure of writing bootcount to file in boot partition due to a bug in uboot FAT implementation.

```
Loading bootcount.env from mmc device 0 partition 1
** Unable to read file bootcount.env **
No bootcount.env file. Setting bootcount=0 in environment
bootcount=1 now
writing bootcount.env
Error: Invalid FAT entry: 0x3ffffffa
```