### PR TITLE
balena-image: Fix ttymxc2 not working on DART6UL

### DIFF
--- a/layers/meta-balena-imx6ul-var-dart/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-core/images/balena-image.inc
@@ -92,6 +92,7 @@ IMAGE_INSTALL_append_imx6ul-var-dart = " \
     brcm-patchram-plus \
     pm-utils \
     pm-services \
+    linux-firmware-imx-sdma-imx6q \
 "
 
 IMAGE_INSTALL_append_var-som-mx6 = " \


### PR DESCRIPTION
If the sdma firmware is not present in the rootfs,
the imx_sdma driver loads the firmware from ROM. However, the
sdma firmware provided by the BSP is the one that
should be used for uarts to work properly.

Changelog-entry: balena-image: Fix ttymxc2 not working on DART6UL
Signed-off-by: Alexandru Costache <alexandru@balena.io>