### PR TITLE
linux-variscite: add spi ind device tree for 6UL Custom board

### DIFF
--- a/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0001-imx6ul-var-dart-Enable-SPI-in-dts.patch
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0001-imx6ul-var-dart-Enable-SPI-in-dts.patch
@@ -1,0 +1,54 @@
+From 35432335fa8fa31403a383cb191aced147b078ca Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Thu, 9 Jun 2022 12:13:17 +0200
+Subject: [PATCH] imx6ul-var-dart: Enable SPI in dts
+
+This is based on https://variwiki.com/index.php?title=DART-6UL_SPI
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ arch/arm/boot/dts/imx6ul-var-dart.dtsi | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/arch/arm/boot/dts/imx6ul-var-dart.dtsi b/arch/arm/boot/dts/imx6ul-var-dart.dtsi
+index 72893786b7d7..e6378b9307b9 100644
+--- a/arch/arm/boot/dts/imx6ul-var-dart.dtsi
++++ b/arch/arm/boot/dts/imx6ul-var-dart.dtsi
+@@ -24,9 +24,33 @@
+ 			MX6UL_PAD_SNVS_TAMPER0__GPIO5_IO00	0x1b0b0 /* fec1 reset */
+ 		>;
+ 	};
++
++	pinctrl_ecspi1_1: ecspi1grp {
++		fsl,pins = <
++			MX6UL_PAD_CSI_DATA07__ECSPI1_MISO       0x100b1
++			MX6UL_PAD_CSI_DATA06__ECSPI1_MOSI       0x100b1
++			MX6UL_PAD_CSI_DATA04__ECSPI1_SCLK       0x100b1
++			MX6UL_PAD_CSI_DATA05__GPIO4_IO26        0x100b1
++		>;
++	};
++
+ };
+ 
+ &adc1 {
+ 	vref-supply = <&touch_3v3_regulator>;
+ 	status = "okay";
+ };
++
++&ecspi1 {
++	fsl,spi-num-chipselects = <1>;
++	cs-gpios = <&gpio4 26 0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi1_1>;
++	status = "okay";
++
++        chip1: spidev@0 {
++               compatible = "var,spidev";
++               spi-max-frequency = <12000000>;
++               reg = <0>;
++        };
++};
+-- 
+2.17.1
+

--- a/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -12,6 +12,10 @@ SRC_URI_append = " \
        file://0002-USB-serial-Add-support-for-more-Quectel-modules.patch \
 "
 
+SRC_URI_append_imx6ul-var-dart = " \
+	file://0001-imx6ul-var-dart-Enable-SPI-in-dts.patch \
+"
+
 SRC_URI_append_imx7-var-som = " \
        file://0001-Add-LED-D10-as-identification-led.patch \
 "


### PR DESCRIPTION
Changelog-entry: linux-variscite: add spidev in the device tree for 6UL Custom board
Signed-off-by: Alexandru Costache <alexandru@balena.io>