### PR TITLE
layers/meta-rust: Remove unused submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "balena-yocto-scripts"]
 	path = balena-yocto-scripts
 	url = https://github.com/balena-os/balena-yocto-scripts.git
-[submodule "layers/meta-rust"]
-	path = layers/meta-rust
-	url = https://github.com/meta-rust/meta-rust.git
 [submodule "layers/meta-freescale"]
 	path = layers/meta-freescale
 	url = https://github.com/Freescale/meta-freescale.git


### PR DESCRIPTION
This layer is now deprecated in favor of rust from meta-balena

Changelog-entry: Remove unused meta-rust submodule since we rely on rust from meta-balena now
Signed-off-by: Florin Sarbu <florin@balena.io>