### PR TITLE
Revert "linux-firmware: Fix broken links for TI repos"

### DIFF
--- a/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,8 +1,0 @@
-# These URIs no longer work
-SRC_URI_remove = "git://git.ti.com/git/wilink8-wlan/wl18xx_fw.git;protocol=https;branch=${BRANCH_tiwlan};destsuffix=tiwlan;name=tiwlan"
-SRC_URI_remove = "git://git.ti.com/git/ti-bt/service-packs.git;protocol=https;branch=${BRANCH_tibt};destsuffix=tibt;name=tibt"
-
-SRC_URI_append = " \
-    git://git.ti.com/wilink8-wlan/wl18xx_fw.git;protocol=git;destsuffix=tiwlan;name=tiwlan \
-    git://git.ti.com/ti-bt/service-packs.git;protocol=git;destsuffix=tibt;name=tibt \
-"


### PR DESCRIPTION
This reverts commit f4d1e78e1764a1e47cc4d58c4659cc1174bb4de1.

The old link started working again while the new ones we added stopped working

Changelog-entry: Revert ti firmware SRC_URI change