### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-imx6ul-var-dart/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx6ul-var-dart/recipes-core/images/balena-image.inc
@@ -25,3 +25,7 @@ do_image_balenaos-img[depends] += " virtual/bootloader:do_deploy"
 # we do not use some packages installed by the BSP
 IMAGE_INSTALL:remove = "packagegroup-tools-bluetooth"
 IMAGE_INSTALL:remove = "packagegroup-variscite-devel"
+
+IMAGE_ROOTFS_SIZE:var-som-mx6 = "327680"
+BALENA_BOOT_SIZE:var-som-mx6 = "40960"
+BALENA_STATE_SIZE:var-som-mx6 = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.